### PR TITLE
support dragging

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Just edit [index.html](index.html) and view it in a browser.
 Execute the following JavaScript code to show candidates:
 ```js
 _select = console.log
+_resize = console.log
 setCandidates(["虚假的", "🀄", "candidates"], 0)
 setLayout(1) // vertical
 ```

--- a/index.html
+++ b/index.html
@@ -69,9 +69,36 @@
       const auxUp = document.querySelector(".aux-up")
       const auxDown = document.querySelector(".aux-down")
 
-      candidates.addEventListener('click', e => {
+      let cursorX = 0
+      let cursorY = 0
+      let pressed = false
+      let dragging = false
+      let startX = 0
+      let startY = 0
+
+      document.addEventListener('mousedown', e => {
+        pressed = true
+        startX = e.clientX
+        startY = e.clientY
+      })
+
+      document.addEventListener('mousemove', e => {
+        if (!pressed) {
+          return
+        }
+        dragging = true
+        // minus because macOS has bottom-left (0, 0)
+        resize(cursorX + (e.clientX - startX), cursorY - (e.clientY - startY))
+      })
+
+      document.addEventListener('mouseup', e => {
+        pressed = false
+        if (dragging) {
+          dragging = false
+          return
+        }
         let { target } = e
-        if (target === candidates) {
+        if (target === candidates || !candidates.contains(target)) {
           return
         }
         while (target.parentElement !== candidates) {
@@ -113,23 +140,25 @@
       }
 
       function resize(x, y) {
+        cursorX = x
+        cursorY = y
         const rect = panel.getBoundingClientRect()
         _resize(x, y, rect.width, rect.height)
       }
 
       function updateElement(element, innerHTML) {
         if (innerHTML === "") {
-            element.classList.add("hidden");
+            element.classList.add("hidden")
         } else {
-            element.innerHTML = innerHTML;
-            element.classList.remove("hidden");
+            element.innerHTML = innerHTML
+            element.classList.remove("hidden")
         }
       }
 
       function updateInputPanel(preeditHTML, auxUpHTML, auxDownHTML) {
-        updateElement(preedit, preeditHTML);
-        updateElement(auxUp, auxUpHTML);
-        updateElement(auxDown, auxDownHTML);
+        updateElement(preedit, preeditHTML)
+        updateElement(auxUp, auxUpHTML)
+        updateElement(auxDown, auxDownHTML)
       }
     </script>
   </body>


### PR DESCRIPTION
It could be tested via preview.
Dragging won't trigger a click on release.
Previously I wanted to pin window after dragging as long as the window isn't hidden (i.e. continuing inputting won't put window back to cursor), but given the native Pinyin doesn't support it either, I'm too lazy to do it before someone else explicitly asks.