### PR TITLE
follow system theme; hack blur

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ setLayout(1)
 // Show aux-up.
 setCandidates([], [], -1)
 updateInputPanel("", "A", "")
+
+// Set theme to 0=system (default), 1=light or 2=dark.
+setTheme(1)
 ```
 
 To change style, just edit [user.scss](./page/user.scss) and refresh the page.

--- a/include/candidate_window.hpp
+++ b/include/candidate_window.hpp
@@ -21,6 +21,8 @@ enum format_t {
 
 template <typename T> using formatted = std::vector<std::pair<T, int>>;
 
+enum theme_t { system = 0, light = 1, dark = 2 };
+
 class CandidateWindow {
   public:
     virtual ~CandidateWindow() = default;
@@ -34,6 +36,7 @@ class CandidateWindow {
                                 const std::vector<std::string> &labels,
                                 int highlighted) = 0;
     virtual void set_highlight_callback(std::function<void(size_t index)>) = 0;
+    virtual void set_theme(theme_t theme) = 0;
     virtual void set_style(const void *style) = 0;
     virtual void show(double x, double y) = 0;
     virtual void hide() = 0;

--- a/include/webview_candidate_window.hpp
+++ b/include/webview_candidate_window.hpp
@@ -23,6 +23,7 @@ class WebviewCandidateWindow : public CandidateWindow {
                         const std::vector<std::string> &labels,
                         int highlighted) override;
     void set_highlight_callback(std::function<void(size_t index)>) override {}
+    void set_theme(theme_t theme) override;
     void set_style(const void *style) override{};
     void show(double x, double y) override;
     void hide() override;

--- a/page/api.ts
+++ b/page/api.ts
@@ -1,50 +1,11 @@
-const panel = document.querySelector('.panel')!
-const candidates = panel.querySelector('.candidates')!
-const preedit = document.querySelector('.preedit')!
-const auxUp = document.querySelector('.aux-up')!
-const auxDown = document.querySelector('.aux-down')!
-
-let cursorX = 0
-let cursorY = 0
-let pressed = false
-let dragging = false
-let startX = 0
-let startY = 0
-
-document.addEventListener('mousedown', e => {
-  pressed = true
-  startX = e.clientX
-  startY = e.clientY
-})
-
-document.addEventListener('mousemove', e => {
-  if (!pressed) {
-    return
-  }
-  dragging = true
-  // minus because macOS has bottom-left (0, 0)
-  resize(cursorX + (e.clientX - startX), cursorY - (e.clientY - startY))
-})
-
-document.addEventListener('mouseup', e => {
-  pressed = false
-  if (dragging) {
-    dragging = false
-    return
-  }
-  let target = e.target as Element
-  if (target === candidates || !candidates.contains(target)) {
-    return
-  }
-  while (target.parentElement !== candidates) {
-    target = target.parentElement!
-  }
-  for (let i = 0; i < candidates.childElementCount; ++i) {
-    if (candidates.children[i] === target) {
-      return window._select(i)
-    }
-  }
-})
+import {
+  candidates,
+  preedit,
+  auxUp,
+  auxDown
+} from './selector'
+import { resize } from './ux'
+import { setTheme } from './theme'
 
 function setLayout (layout : 0 | 1) {
   switch (layout) {
@@ -78,13 +39,6 @@ function setCandidates (cands: string[], labels: string[], highlighted: number) 
   }
 }
 
-function resize (x: number, y: number) {
-  cursorX = x
-  cursorY = y
-  const rect = panel.getBoundingClientRect()
-  window._resize(x, y, rect.width, rect.height)
-}
-
 function updateElement (element: Element, innerHTML: string) {
   if (innerHTML === '') {
     element.classList.add('hidden')
@@ -100,8 +54,11 @@ function updateInputPanel (preeditHTML: string, auxUpHTML: string, auxDownHTML: 
   updateElement(auxDown, auxDownHTML)
 }
 
+setTheme(0)
+
 // JavaScript APIs that webview_candidate_window.mm calls
 window.setCandidates = setCandidates
 window.setLayout = setLayout
 window.updateInputPanel = updateInputPanel
 window.resize = resize
+window.setTheme = setTheme

--- a/page/generic.scss
+++ b/page/generic.scss
@@ -44,3 +44,7 @@ body {
 .hidden {
   display: none;
 }
+
+.blur {
+  backdrop-filter: blur(16px); /* blur background */
+}

--- a/page/global.d.ts
+++ b/page/global.d.ts
@@ -3,6 +3,13 @@ declare global {
     // C++ APIs that api.ts calls
     _select: (index: number) => void
     _resize: (x: number, y: number, width: number, height: number) => void
+
+    // JavaScript APIs that webview_candidate_window.mm calls
+    setCandidates: (cands: string[], labels: string[], highlighted: number) => void
+    setLayout: (layout: 0 | 1) => void
+    updateInputPanel: (preeditHTML: string, auxUpHTML: string, auxDownHTML: string) => void
+    resize: (x: number, y: number) => void
+    setTheme: (theme: 0 | 1 | 2) => void
   }
 }
 

--- a/page/index.html
+++ b/page/index.html
@@ -13,12 +13,14 @@
   </head>
   <body>
     <div class="panel macos">
-      <div class="header">
-        <div class="aux-up hidden"></div>
-        <div class="preedit hidden"></div>
-      </div>
-      <div class="aux-down hidden"></div>
-      <div class="candidates">
+      <div class="panel-blur">
+        <div class="header">
+          <div class="aux-up hidden"></div>
+          <div class="preedit hidden"></div>
+        </div>
+        <div class="aux-down hidden"></div>
+        <div class="candidates">
+        </div>
       </div>
     </div>
     <script type="module">

--- a/page/macos.scss
+++ b/page/macos.scss
@@ -1,24 +1,74 @@
 /* use Digital Color Meter with sRGB mode to get correct color */
+$panel-alpha: 0.8125;
+
+/* light */
+$panel-color-light: rgba(240, 240, 240, $panel-alpha);
+$panel-border-color-light: rgb(0 0 0 / 17.5%);
+$vertical-border-color-light: rgba(224, 224, 224, $panel-alpha);
+$text-color-light: rgb(0 0 0 / 70%);
+
+/* dark */
+$panel-color-dark: rgba(60, 60, 60, $panel-alpha);
+$panel-border-color-dark: rgb(0 0 0 / 47.5%);
+$vertical-border-color-dark: rgba(85, 85, 85, $panel-alpha);
+$text-color-dark: rgb(255 255 255 / 90%);
+
+/* accent color */
+$light-blue: rgb(0 90 216);
+$dark-blue: rgb(0 89 208);
+
 .macos {
   &.panel {
-    border: 1px solid #5c5c5c;
     border-radius: 6px;
-    background-color: #333;
+    background-clip: padding-box; /* make border alpha and content alpha independent */
     font-family: sans-serif;
   }
 
   .candidate, .preedit, .aux-up, .aux-down {
-    color: white;
     min-height: 24px; /* compromise to 🀄's height */
     min-width: 16px;
     padding: 3px 7px; /* combine min-height, min-width and padding to make aux-up a square for 小 and A */
+    background-clip: padding-box;
+  }
+}
+
+.macos.light {
+  &.panel {
+    border: 1px solid $panel-border-color-light;
+  }
+
+  .candidate, .preedit, .aux-up, .aux-down {
+    color: $text-color-light;
+    background-color: $panel-color-light;
   }
 
   .candidate.highlighted {
-    background-color: #0059d0;
+    color: white;
+    background-color: $light-blue;
   }
 
   .candidates.vertical .candidate:not(:first-child) {
-    border-top: 1px solid #5c5c5c;
+    border-top: 1px solid $vertical-border-color-light;
+  }
+}
+
+.macos.dark {
+  &.panel {
+    border: 1px solid $panel-border-color-dark;
+  }
+
+  /* stylelint-disable-next-line no-descending-specificity */
+  .candidate, .preedit, .aux-up, .aux-down {
+    color: $text-color-dark;
+    background-color: $panel-color-dark;
+  }
+
+  .candidate.highlighted {
+    color: white;
+    background-color: $dark-blue;
+  }
+
+  .candidates.vertical .candidate:not(:first-child) {
+    border-top: 1px solid $vertical-border-color-dark;
   }
 }

--- a/page/selector.ts
+++ b/page/selector.ts
@@ -1,0 +1,5 @@
+export const panel = document.querySelector('.panel')!
+export const candidates = panel.querySelector('.candidates')!
+export const preedit = document.querySelector('.preedit')!
+export const auxUp = document.querySelector('.aux-up')!
+export const auxDown = document.querySelector('.aux-down')!

--- a/page/theme.ts
+++ b/page/theme.ts
@@ -1,0 +1,49 @@
+import {
+  panel
+} from './selector'
+
+const darkMQL = window.matchMedia('(prefers-color-scheme: dark)')
+let isSystemDark = darkMQL.matches
+let followSystemTheme = true
+
+function setLightTheme () {
+  panel.classList.remove('dark')
+  panel.classList.add('light')
+}
+
+function setDarkTheme () {
+  panel.classList.remove('light')
+  panel.classList.add('dark')
+}
+
+function systemThemeHandler () {
+  if (isSystemDark) {
+    setDarkTheme()
+  } else {
+    setLightTheme()
+  }
+}
+
+darkMQL.addEventListener('change', event => {
+  isSystemDark = event.matches
+  if (followSystemTheme) {
+    systemThemeHandler()
+  }
+})
+
+export function setTheme (theme: 0 | 1 | 2) {
+  switch (theme) {
+    case 0:
+      followSystemTheme = true
+      systemThemeHandler()
+      break
+    case 1:
+      followSystemTheme = false
+      setLightTheme()
+      break
+    case 2:
+      followSystemTheme = false
+      setDarkTheme()
+      break
+  }
+}

--- a/page/ux.ts
+++ b/page/ux.ts
@@ -1,0 +1,53 @@
+import {
+  panel,
+  candidates
+} from './selector'
+
+let cursorX = 0
+let cursorY = 0
+let pressed = false
+let dragging = false
+let startX = 0
+let startY = 0
+
+export function resize (x: number, y: number) {
+  cursorX = x
+  cursorY = y
+  const rect = panel.getBoundingClientRect()
+  window._resize(x, y, rect.width, rect.height)
+}
+
+document.addEventListener('mousedown', e => {
+  pressed = true
+  startX = e.clientX
+  startY = e.clientY
+})
+
+document.addEventListener('mousemove', e => {
+  if (!pressed) {
+    return
+  }
+  dragging = true
+  // minus because macOS has bottom-left (0, 0)
+  resize(cursorX + (e.clientX - startX), cursorY - (e.clientY - startY))
+})
+
+document.addEventListener('mouseup', e => {
+  pressed = false
+  if (dragging) {
+    dragging = false
+    return
+  }
+  let target = e.target as Element
+  if (target === candidates || !candidates.contains(target)) {
+    return
+  }
+  while (target.parentElement !== candidates) {
+    target = target.parentElement!
+  }
+  for (let i = 0; i < candidates.childElementCount; ++i) {
+    if (candidates.children[i] === target) {
+      return window._select(i)
+    }
+  }
+})

--- a/page/ux.ts
+++ b/page/ux.ts
@@ -51,3 +51,21 @@ document.addEventListener('mouseup', e => {
     }
   }
 })
+
+// HACK: force redraw blur every 40ms so that window background change counts
+let blurSwitch = false
+const panelBlur = document.querySelector('.panel-blur')!
+function redrawBlur () {
+  if (!panel.classList.contains('macos')) {
+    return
+  }
+  if (blurSwitch) {
+    panelBlur.classList.add('blur')
+    panel.classList.remove('blur')
+  } else {
+    panel.classList.add('blur')
+    panelBlur.classList.remove('blur')
+  }
+  blurSwitch = !blurSwitch
+}
+setInterval(redrawBlur, 40)

--- a/preview/preview.mm
+++ b/preview/preview.mm
@@ -19,6 +19,7 @@ int main(int argc, const char *argv[]) {
             candidateWindow->set_layout(candidate_window::layout_t::vertical);
             candidateWindow->set_candidates({"虚假的", "候选词"}, {"1", "2"},
                                             0);
+            candidateWindow->set_theme(candidate_window::theme_t::light);
             candidateWindow->show(100, 200);
         });
         [application run];

--- a/src/webview_candidate_window.mm
+++ b/src/webview_candidate_window.mm
@@ -68,6 +68,10 @@ void WebviewCandidateWindow::set_candidates(
     invoke_js("setCandidates", candidates, labels, highlighted);
 }
 
+void WebviewCandidateWindow::set_theme(theme_t theme) {
+    invoke_js("setTheme", theme);
+}
+
 void WebviewCandidateWindow::show(double x, double y) {
     invoke_js("resize", x, y);
 }

--- a/tests/test-generic.spec.ts
+++ b/tests/test-generic.spec.ts
@@ -14,24 +14,30 @@ import {
 
 test('HTML structure', async ({ page }) => {
   await init(page)
+  await page.evaluate(() => {
+    document.querySelector('.panel')?.classList.remove('macos', 'blur')
+    document.querySelector('.panel-blur')?.classList.remove('blur')
+  })
   await setCandidates(page, ['页面结构', '测试'], ['1', '2'], 0)
 
   const actual = (await panel(page).evaluate(el => el.outerHTML)).replaceAll('> <', '><')
   const expected = `
-<div class="macos panel dark">
-  <div class="header">
-    <div class="aux-up hidden"></div>
-    <div class="hidden preedit"></div>
-  </div>
-  <div class="aux-down hidden"></div>
-  <div class="candidates">
-    <div class="candidate highlighted">
-      <div class="label">1</div>
-      <div class="text">页面结构</div>
+<div class="panel dark">
+  <div class="panel-blur">
+    <div class="header">
+      <div class="aux-up hidden"></div>
+      <div class="hidden preedit"></div>
     </div>
-    <div class="candidate">
-      <div class="label">2</div>
-      <div class="text">测试</div>
+    <div class="aux-down hidden"></div>
+    <div class="candidates">
+      <div class="candidate highlighted">
+        <div class="label">1</div>
+        <div class="text">页面结构</div>
+      </div>
+      <div class="candidate">
+        <div class="label">2</div>
+        <div class="text">测试</div>
+      </div>
     </div>
   </div>
 </div>

--- a/tests/test-generic.spec.ts
+++ b/tests/test-generic.spec.ts
@@ -18,7 +18,7 @@ test('HTML structure', async ({ page }) => {
 
   const actual = (await panel(page).evaluate(el => el.outerHTML)).replaceAll('> <', '><')
   const expected = `
-<div class="macos panel">
+<div class="macos panel dark">
   <div class="header">
     <div class="aux-up hidden"></div>
     <div class="hidden preedit"></div>

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -8,6 +8,7 @@ export async function init (page: Page) {
   const url = 'file://' + join(dirname(import.meta.url), '..', 'dist', 'index.html').substring('file:'.length)
   await page.goto(url)
   await page.evaluate(() => {
+    window.setTheme(2)
     window.cppCalls = []
     window._resize = (x: number, y: number, width: number, height: number) => {
       window.cppCalls.push({


### PR DESCRIPTION
Tested with fcitx5-macos for
* Changing system theme automatically changes candidate window color.
* Moving candidate window around should update blur.
* Moving client window around should also update blur.
<img width="204" alt="Screenshot 2024-02-03 at 9 54 17 PM" src="https://github.com/fcitx-contrib/fcitx5-webview/assets/26783539/ade7dcd9-9609-406d-9ec4-9cf7239ee3ef">