### PR TITLE
fix: flicker on bottom, sticky dragging, no highlight color

### DIFF
--- a/include/webview_candidate_window.hpp
+++ b/include/webview_candidate_window.hpp
@@ -34,6 +34,8 @@ class WebviewCandidateWindow : public CandidateWindow {
     void set_transparent_background();
     webview::webview w_;
     void *listener_;
+    bool hidden_ = true;
+    bool was_above_ = false;
     bool first_draw_ = true;
     int accent_color_ = 0;
 

--- a/include/webview_candidate_window.hpp
+++ b/include/webview_candidate_window.hpp
@@ -35,6 +35,10 @@ class WebviewCandidateWindow : public CandidateWindow {
     void set_transparent_background();
     webview::webview w_;
     void *listener_;
+    double cursor_x_ = 0;
+    double cursor_y_ = 0;
+    double x_ = 0;
+    double y_ = 0;
     bool hidden_ = true;
     bool was_above_ = false;
     bool accent_color_nil_ = false;

--- a/include/webview_candidate_window.hpp
+++ b/include/webview_candidate_window.hpp
@@ -29,6 +29,7 @@ class WebviewCandidateWindow : public CandidateWindow {
     void hide() override;
 
     void update_accent_color();
+    void set_accent_color();
 
   private:
     void set_transparent_background();
@@ -36,7 +37,7 @@ class WebviewCandidateWindow : public CandidateWindow {
     void *listener_;
     bool hidden_ = true;
     bool was_above_ = false;
-    bool first_draw_ = true;
+    bool accent_color_nil_ = false;
     int accent_color_ = 0;
 
   private:

--- a/page/global.d.ts
+++ b/page/global.d.ts
@@ -2,13 +2,13 @@ declare global {
   interface Window {
     // C++ APIs that api.ts calls
     _select: (index: number) => void
-    _resize: (x: number, y: number, width: number, height: number) => void
+    _resize: (x: number, y: number, width: number, height: number, dragging: boolean) => void
 
     // JavaScript APIs that webview_candidate_window.mm calls
     setCandidates: (cands: string[], labels: string[], highlighted: number) => void
     setLayout: (layout: 0 | 1) => void
     updateInputPanel: (preeditHTML: string, auxUpHTML: string, auxDownHTML: string) => void
-    resize: (x: number, y: number) => void
+    resize: (x: number, y: number, dragging: boolean) => void
     setTheme: (theme: 0 | 1 | 2) => void
     setAccentColor: (color: number | null) => void
   }

--- a/page/global.d.ts
+++ b/page/global.d.ts
@@ -2,13 +2,13 @@ declare global {
   interface Window {
     // C++ APIs that api.ts calls
     _select: (index: number) => void
-    _resize: (x: number, y: number, width: number, height: number, dragging: boolean) => void
+    _resize: (dx: number, dy: number, width: number, height: number, dragging: boolean) => void
 
     // JavaScript APIs that webview_candidate_window.mm calls
     setCandidates: (cands: string[], labels: string[], highlighted: number) => void
     setLayout: (layout: 0 | 1) => void
     updateInputPanel: (preeditHTML: string, auxUpHTML: string, auxDownHTML: string) => void
-    resize: (x: number, y: number, dragging: boolean) => void
+    resize: (dx: number, dy: number, dragging: boolean) => void
     setTheme: (theme: 0 | 1 | 2) => void
     setAccentColor: (color: number | null) => void
   }

--- a/page/index.html
+++ b/page/index.html
@@ -12,7 +12,7 @@
     </style>
   </head>
   <body>
-    <div class="panel macos">
+    <div class="panel macos blue">
       <div class="panel-blur">
         <div class="header">
           <div class="aux-up hidden"></div>

--- a/page/ux.ts
+++ b/page/ux.ts
@@ -10,11 +10,11 @@ let dragging = false
 let startX = 0
 let startY = 0
 
-export function resize (x: number, y: number) {
+export function resize (x: number, y: number, dragging: boolean) {
   cursorX = x
   cursorY = y
   const rect = panel.getBoundingClientRect()
-  window._resize(x, y, rect.width, rect.height)
+  window._resize(x, y, rect.width, rect.height, dragging)
 }
 
 document.addEventListener('mousedown', e => {
@@ -29,7 +29,7 @@ document.addEventListener('mousemove', e => {
   }
   dragging = true
   // minus because macOS has bottom-left (0, 0)
-  resize(cursorX + (e.clientX - startX), cursorY - (e.clientY - startY))
+  resize(cursorX + (e.clientX - startX), cursorY - (e.clientY - startY), true)
 })
 
 document.addEventListener('mouseup', e => {

--- a/page/ux.ts
+++ b/page/ux.ts
@@ -3,18 +3,14 @@ import {
   candidates
 } from './selector'
 
-let cursorX = 0
-let cursorY = 0
 let pressed = false
 let dragging = false
 let startX = 0
 let startY = 0
 
-export function resize (x: number, y: number, dragging: boolean) {
-  cursorX = x
-  cursorY = y
+export function resize (dx: number, dy: number, dragging: boolean) {
   const rect = panel.getBoundingClientRect()
-  window._resize(x, y, rect.width, rect.height, dragging)
+  window._resize(dx, dy, rect.width, rect.height, dragging)
 }
 
 document.addEventListener('mousedown', e => {
@@ -29,7 +25,7 @@ document.addEventListener('mousemove', e => {
   }
   dragging = true
   // minus because macOS has bottom-left (0, 0)
-  resize(cursorX + (e.clientX - startX), cursorY - (e.clientY - startY), true)
+  resize(e.clientX - startX, -(e.clientY - startY), true)
 })
 
 document.addEventListener('mouseup', e => {

--- a/src/webview_candidate_window.mm
+++ b/src/webview_candidate_window.mm
@@ -41,16 +41,19 @@ WebviewCandidateWindow::WebviewCandidateWindow()
              object:nil];
     update_accent_color();
 
-    bind("_resize", [this](double x, double y, double width, double height) {
+    bind("_resize", [this](double x, double y, double width, double height,
+                           bool dragging) {
         const int gap = 4;
         const int preedit_height = 24;
         int screen_width = [[NSScreen mainScreen] frame].size.width;
 
-        if (x + width > screen_width) {
-            x = screen_width - width;
-        }
-        if (x < 0) {
-            x = 0;
+        if (!dragging) {
+            if (x + width > screen_width) {
+                x = screen_width - width;
+            }
+            if (x < 0) {
+                x = 0;
+            }
         }
         if ((hidden_ && height + gap > y)  // No enough space underneath
             || (!hidden_ && was_above_)) { // It was above, avoid flicker
@@ -130,7 +133,7 @@ void WebviewCandidateWindow::show(double x, double y) {
         // warmed-up yet, and it won't be updated until user changes color.
         set_accent_color();
     }
-    invoke_js("resize", x, y);
+    invoke_js("resize", x, y, false);
 }
 
 void WebviewCandidateWindow::hide() {

--- a/src/webview_candidate_window.mm
+++ b/src/webview_candidate_window.mm
@@ -50,11 +50,15 @@ WebviewCandidateWindow::WebviewCandidateWindow()
         if (x < 0) {
             x = 0;
         }
-        if (height + gap > y) { // No enough space underneath
+        if ((hidden_ && height + gap > y)  // No enough space underneath
+            || (!hidden_ && was_above_)) { // It was above, avoid flicker
             y = std::max<double>(y + preedit_height + gap, 0);
+            was_above_ = true;
         } else {
             y -= height + gap;
+            was_above_ = false;
         }
+        hidden_ = false;
 
         NSWindow *window = static_cast<NSWindow *>(w_.window());
         [window setFrame:NSMakeRect(x, y, width, height)
@@ -108,6 +112,7 @@ void WebviewCandidateWindow::set_theme(theme_t theme) {
 }
 
 void WebviewCandidateWindow::show(double x, double y) {
+    // It's _resize which is called by resize that actually shows the window
     if (first_draw_) {
         first_draw_ = false;
         update_accent_color();
@@ -119,6 +124,7 @@ void WebviewCandidateWindow::hide() {
     auto window = static_cast<NSWindow *>(w_.window());
     [window orderBack:nil];
     [window setIsVisible:NO];
+    hidden_ = true;
 }
 
 static void build_html_open_tags(std::stringstream &ss, int flags) {

--- a/tests/global.d.ts
+++ b/tests/global.d.ts
@@ -1,6 +1,6 @@
 declare global {
   type CppCall = {
-    resize: [number, number, number, number]
+    resize: [number, number, number, number, boolean]
   } | {
     select: number
   }

--- a/tests/test-generic.spec.ts
+++ b/tests/test-generic.spec.ts
@@ -22,7 +22,7 @@ test('HTML structure', async ({ page }) => {
 
   const actual = (await panel(page).evaluate(el => el.outerHTML)).replaceAll('> <', '><')
   const expected = `
-<div class="panel dark">
+<div class="blue panel dark">
   <div class="panel-blur">
     <div class="header">
       <div class="aux-up hidden"></div>

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -10,9 +10,9 @@ export async function init (page: Page) {
   await page.evaluate(() => {
     window.setTheme(2)
     window.cppCalls = []
-    window._resize = (x: number, y: number, width: number, height: number, dragging: boolean) => {
+    window._resize = (dx: number, dy: number, width: number, height: number, dragging: boolean) => {
       window.cppCalls.push({
-        resize: [x, y, width, height, dragging]
+        resize: [dx, dy, width, height, dragging]
       })
     }
     window._select = (index: number) => {

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -10,9 +10,9 @@ export async function init (page: Page) {
   await page.evaluate(() => {
     window.setTheme(2)
     window.cppCalls = []
-    window._resize = (x: number, y: number, width: number, height: number) => {
+    window._resize = (x: number, y: number, width: number, height: number, dragging: boolean) => {
       window.cppCalls.push({
-        resize: [x, y, width, height]
+        resize: [x, y, width, height, dragging]
       })
     }
     window._select = (index: number) => {


### PR DESCRIPTION
First revert Info.plist change in https://github.com/fcitx-contrib/fcitx5-macos/pull/36
Reproduce the 3 bugs on master:
* Put input client near screen bottom so that when there are less number of candidates the window could fit below, but when there are more candidates it couldn't. Use rime's F4 and ArrowDown to switch page, you will see the first page (full candidates) above cursor and last page (less candidates) below cursor, so there's flicker.
* Build and install Fcitx5, switch to next IM, pkill Fcitx5, quickly switch back and type something in terminal. The first key may not trigger window as webview may not warm up yet, then subsequent keys may show a window without highlight.
* Drag the window near left/right/bottom boundary of the screen, it's sticky.