### PR TITLE
fix crash on fast scroll

### DIFF
--- a/include/webview_candidate_window.hpp
+++ b/include/webview_candidate_window.hpp
@@ -55,7 +55,10 @@ class WebviewCandidateWindow : public CandidateWindow {
         if constexpr (debug) {
             std::cerr << ss.str() << "\n";
         }
-        w_.eval(ss.str());
+        auto s = ss.str();
+        dispatch_async(dispatch_get_main_queue(), ^{
+          w_.eval(s);
+        });
     }
 
     template <typename T>


### PR DESCRIPTION
We have seen it before, but this is highly reproducible if using two-finger scroll or MagSpeed.
Instead of wrapping everywhere, better to do it at the root.