### PR TITLE
try fixing intermittent narrower window

### DIFF
--- a/page/ux.ts
+++ b/page/ux.ts
@@ -18,15 +18,22 @@ type ShadowBox = {
 }
 
 export function resize (dx: number, dy: number, dragging: boolean) {
-  const {
-    shadowTop,
-    shadowRight,
-    shadowBottom,
-    shadowLeft,
-    fullWidth,
-    fullHeight
-  } = getBoundingRectWithShadow(panel)
-  window._resize(dx, dy, shadowTop, shadowRight, shadowBottom, shadowLeft, fullWidth, fullHeight, dragging)
+  function adaptWindowSize () {
+    const {
+      shadowTop,
+      shadowRight,
+      shadowBottom,
+      shadowLeft,
+      fullWidth,
+      fullHeight
+    } = getBoundingRectWithShadow(panel)
+    window._resize(dx, dy, shadowTop, shadowRight, shadowBottom, shadowLeft, fullWidth, fullHeight, dragging)
+  }
+  adaptWindowSize()
+  if (!dragging) {
+    // Sometimes getBoundingClientRect is called when the element is not fully rendered.
+    window.requestAnimationFrame(adaptWindowSize)
+  }
 }
 
 function getBoundingRectWithShadow (element: Element): ShadowBox {


### PR DESCRIPTION
To reproduce it, apply this patch on current branch, which forces to render based on sizes calculated last time.
```patch
diff --git a/page/ux.ts b/page/ux.ts
index f34708b..4b16fa1 100644
--- a/page/ux.ts
+++ b/page/ux.ts
@@ -32,10 +32,12 @@ export function resize (dx: number, dy: number, dragging: boolean) {
   adaptWindowSize()
   if (!dragging) {
     // Sometimes getBoundingClientRect is called when the element is not fully rendered.
-    window.requestAnimationFrame(adaptWindowSize)
+    // window.requestAnimationFrame(adaptWindowSize)
   }
 }
 
+let last = {}
+
 function getBoundingRectWithShadow (element: Element): ShadowBox {
   const rect = element.getBoundingClientRect()
   const elementXHi = rect.x + rect.width
@@ -62,7 +64,8 @@ function getBoundingRectWithShadow (element: Element): ShadowBox {
   // rect.height and rect.width will cover the whole panel and its shadow.
   rect.width = xHi
   rect.height = yHi
-  return {
+  const now = last
+  last = {
     shadowTop: rect.y,
     shadowRight: xHi - elementXHi,
     shadowBottom: yHi - elementYHi,
@@ -70,6 +73,7 @@ function getBoundingRectWithShadow (element: Element): ShadowBox {
     fullWidth: xHi,
     fullHeight: yHi
   }
+  return now
 }
 
 document.addEventListener('mousedown', e => {
```
In Pinyin, type `a` `s`, you should see
<img width="435" alt="narrow" src="https://github.com/fcitx-contrib/fcitx5-webview/assets/26783539/16109e8e-4f67-41a6-b0e4-95cd40eee3a1">
every time.
Then uncomment `window.requestAnimationFrame(adaptWindowSize)`, you should see
<img width="497" alt="normal" src="https://github.com/fcitx-contrib/fcitx5-webview/assets/26783539/90393dbe-b4a3-44cc-9d2e-92e09c4053a0">
every time.