### PR TITLE
fix highlight: no mouse move; mouse move out of panel from paging button

### DIFF
--- a/page/api.ts
+++ b/page/api.ts
@@ -172,7 +172,7 @@ function setCandidates (cands: Candidate[], highlighted: number, markText: strin
 
   if (scrollState === 1) {
     hoverables.append(divider(true))
-    const expand = div('fcitx-expand', 'fcitx-hoverable-inner')
+    const expand = div('fcitx-expand', 'fcitx-paging-inner', 'fcitx-hoverable-inner')
     expand.innerHTML = arrowForward
     const paging = div('fcitx-paging', 'fcitx-scroll', 'fcitx-hoverable')
     paging.append(expand)

--- a/page/customize.ts
+++ b/page/customize.ts
@@ -113,9 +113,9 @@ const HIGHLIGHT_ORIGINAL_MARK = `${PANEL} .fcitx-highlighted-original .fcitx-mar
 
 const PANEL_LIGHT = `.fcitx-light${PANEL}`
 const PANEL_LIGHT_HIGHLIGHT = `${PANEL_LIGHT} .fcitx-hoverable.fcitx-highlighted .fcitx-hoverable-inner`
-const PANEL_LIGHT_HIGHLIGHT_HOVER = `${PANEL_LIGHT} .fcitx-hoverable.fcitx-highlighted:hover .fcitx-hoverable-inner`
+const PANEL_LIGHT_HIGHLIGHT_HOVER = `${PANEL_LIGHT} .fcitx-mousemoved .fcitx-hoverable.fcitx-highlighted:hover .fcitx-hoverable-inner`
 const PANEL_LIGHT_HIGHLIGHT_PRESS = `${PANEL_LIGHT} .fcitx-hoverable.fcitx-highlighted:active .fcitx-hoverable-inner`
-const PANEL_LIGHT_OTHER_HOVER = `${PANEL_LIGHT} .fcitx-hoverable:not(.fcitx-highlighted):hover .fcitx-hoverable-inner`
+const PANEL_LIGHT_OTHER_HOVER = `${PANEL_LIGHT} .fcitx-mousemoved .fcitx-hoverable:not(.fcitx-highlighted):hover .fcitx-hoverable-inner`
 const PANEL_LIGHT_OTHER_PRESS = `${PANEL_LIGHT} .fcitx-hoverable:not(.fcitx-highlighted):active .fcitx-hoverable-inner`
 const TEXT_LIGHT_HIGHLIGHT = `${PANEL_LIGHT} .fcitx-candidate.fcitx-highlighted .fcitx-text`
 const TEXT_LIGHT_PRESS = `${PANEL_LIGHT} .fcitx-candidate:active .fcitx-candidate-inner .fcitx-text`

--- a/page/ux.ts
+++ b/page/ux.ts
@@ -21,6 +21,13 @@ let dX = 0
 let dY = 0
 let dragOffset = 0
 
+// 0: reset, 1: initial (when window is shown even if no mouse move there will be a mousemove event), 2+: moved
+let mouseMoveState = 0
+export function resetMouseMoveState () {
+  mouseMoveState = 0
+  hoverables.classList.remove('fcitx-mousemoved')
+}
+
 type ShadowBox = {
   anchorTop: number,
   anchorRight: number,
@@ -167,6 +174,9 @@ document.addEventListener('mousedown', e => {
 })
 
 document.addEventListener('mousemove', e => {
+  if (++mouseMoveState >= 2) {
+    hoverables.classList.add('fcitx-mousemoved')
+  }
   if (e.button !== 0 || !pressed) {
     return
   }


### PR DESCRIPTION
Test:
* In Add or Move mode, initial mouse position shouldn't affect highlight.
* In Move mode, when mouse moves out from paging button, highlight mark should go back to original highlighted candidate.
* Scroll expand button should have border-radius for win11 theme.