### PR TITLE
fix last candidate jumps to next row in scroll mode

### DIFF
--- a/page/scroll.ts
+++ b/page/scroll.ts
@@ -137,8 +137,8 @@ export function recalculateScroll(scrollStart: boolean) {
   rowItemCount.push(itemCount)
   renderHighlightAndLabels(scrollStart ? 0 : highlighted, !scrollStart)
 
-  // Manually adjust last row so that candidates align left.
-  if (scrollEnd) {
+  // Manually adjust last row if less than MAX_COLUMN candidates so that they align left.
+  if (scrollEnd && rowItemCount[rowItemCount.length - 1] < MAX_COLUMN) {
     const dividers = hoverables.querySelectorAll('.fcitx-divider')
     const skipped = itemCountInFirstNRows(rowItemCount.length - 1)
     const { width } = dividers[skipped - 1].getBoundingClientRect() // Don't use clientWidth as it rounds to integer.


### PR DESCRIPTION
Reproduce: `pnpm run dev`
```js
setCandidates([
    { text: "忒", label: "1", comment: "", actions: [] },
    { text: "忒", label: "1", comment: "", actions: [] },
    { text: "忒", label: "1", comment: "", actions: [] },
    { text: "忒", label: "1", comment: "", actions: [] },
    { text: "忒", label: "1", comment: "", actions: [] },
    { text: "忒", label: "1", comment: "", actions: [] },
    { text: "忒", label: "1", comment: "", actions: [] },
    { text: "蜕", label: "2", comment: "", actions: [] },
    { text: "褪", label: "3", comment: "", actions: [] },
    { text: "魋", label: "4", comment: "", actions: [] },
    { text: "隤", label: "5", comment: "", actions: [] },
    { text: "tuition", label: "6", comment: "", actions: [] }],
    0, "", true, false, true, 2, true, true)
```