### PR TITLE
fix: do not enlarge gap of last row

### DIFF
--- a/page/scroll.ts
+++ b/page/scroll.ts
@@ -141,9 +141,12 @@ export function recalculateScroll(scrollStart: boolean) {
   if (scrollEnd && rowItemCount[rowItemCount.length - 1] < MAX_COLUMN) {
     const dividers = hoverables.querySelectorAll('.fcitx-divider')
     const skipped = itemCountInFirstNRows(rowItemCount.length - 1)
-    const { width } = dividers[skipped - 1].getBoundingClientRect() // Don't use clientWidth as it rounds to integer.
-    for (let i = skipped; i < skipped + rowItemCount[rowItemCount.length - 1] - 1; ++i) {
-      dividers[i].setAttribute('style', `flex-grow: 0; flex-basis: ${width}px`)
+    const { width: gapOfPreviousRow } = dividers[skipped - 1].getBoundingClientRect() // Don't use clientWidth as it rounds to integer.
+    const { width: gapOfLastRow } = dividers[skipped].getBoundingClientRect()
+    if (gapOfLastRow > gapOfPreviousRow) {
+      for (let i = skipped; i < skipped + rowItemCount[rowItemCount.length - 1] - 1; ++i) {
+        dividers[i].setAttribute('style', `flex-grow: 0; flex-basis: ${gapOfPreviousRow}px`)
+      }
     }
   }
 }


### PR DESCRIPTION
reproduce:
```js
setCandidates([
  { "actions": [], "comment": "", "label": "", "text": "朙月拼音·語句流" },
  { "actions": [], "comment": "", "label": "", "text": "中／半／漢／。／開" },
  { "actions": [], "comment": "", "label": "", "text": "五筆畫" },
  { "actions": [], "comment": "", "label": "", "text": "朙月拼音" },
  { "actions": [], "comment": "", "label": "", "text": "朙月拼音·臺灣正體" },
  { "actions": [], "comment": "", "label": "", "text": "朙月拼音·简化字" }],
-1, '', true, false, true, 2, true, true)
```