### PR TITLE
fix: set highlight on expand

### DIFF
--- a/page/scroll.ts
+++ b/page/scroll.ts
@@ -104,6 +104,7 @@ function scrollForHighlight() {
 }
 
 function renderHighlightAndLabels(newHighlighted: number, clearOld: boolean) {
+  window.fcitx._highlight(newHighlighted) // Call it on both expand and highlight move.
   const candidates = hoverables.querySelectorAll('.fcitx-candidate')
   if (clearOld) {
     const highlightedRow = getHighlightedRow()
@@ -248,7 +249,6 @@ export function scrollKeyAction(action: SCROLL_KEY_ACTION) {
     case PAGE_DOWN: {
       const newHighlighted = getNeighborCandidate(highlighted, action)
       if (newHighlighted >= 0) {
-        window.fcitx._highlight(newHighlighted)
         renderHighlightAndLabels(newHighlighted, true)
         scrollForHighlight()
         if (!scrollEnd && !fetching) {

--- a/tests/global.d.ts
+++ b/tests/global.d.ts
@@ -5,6 +5,8 @@ declare global {
     select: number
   } | {
     action: [number, number]
+  } | {
+    highlight: number
   }
 
   interface Window {

--- a/tests/test-scroll.spec.ts
+++ b/tests/test-scroll.spec.ts
@@ -1,0 +1,10 @@
+import test, { expect } from '@playwright/test'
+import { candidate, init, scrollExpand } from './util'
+
+test('Passively expand', async ({ page }) => {
+  await init(page)
+  await scrollExpand(page, ['1', '2', '3', '4', '5', '6', '7'])
+  await expect(candidate(page, 0)).toContainClass('fcitx-highlighted')
+  const cppCalls = await page.evaluate(() => window.cppCalls)
+  expect(cppCalls[0], 'Highlight is set on expand').toEqual({ highlight: 0 })
+})

--- a/tests/test-theme.spec.ts
+++ b/tests/test-theme.spec.ts
@@ -24,6 +24,6 @@ test('Set accent color', async ({ page }) => {
 
   for (const [value, color] of cases) {
     await page.evaluate(value => window.fcitx.setAccentColor(value), value)
-    await expect(theme(page)).toHaveClass(new RegExp(color))
+    await expect(theme(page)).toContainClass(color)
   }
 })

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -25,6 +25,11 @@ export async function init(page: Page) {
         action: [index, id],
       })
     }
+    window.fcitx._highlight = (index: number) => {
+      window.cppCalls.push({
+        highlight: index,
+      })
+    }
     window.fcitx._log = () => {}
   })
 }
@@ -32,6 +37,12 @@ export async function init(page: Page) {
 export function setCandidates(page: Page, cands: Candidate[], highlighted: number) {
   return page.evaluate(({ cands, highlighted }) =>
     window.fcitx.setCandidates(cands, highlighted, '', false, false, false, 0, false, false), { cands, highlighted })
+}
+
+export function scrollExpand(page: Page, texts: string[]) {
+  const cands = texts.map(text => ({ text, label: '', comment: '', actions: [] }))
+  return page.evaluate(({ cands }) =>
+    window.fcitx.setCandidates(cands, -1, '', false, false, false, 2, false, false), { cands })
 }
 
 export function setLayout(page: Page, layout: 0 | 1) {


### PR DESCRIPTION
Reproduce: In rime prepare 2 user words with the same input and make one as the first candidate. Use ArrowRight to highlight the other one. Expand. Now highlight is on the first candidate, but Shift+Delete removes the other one.