### PR TITLE
f5j: drop requestAnimationFrame as it doesn't guarantee render

### DIFF
--- a/page/api.ts
+++ b/page/api.ts
@@ -124,13 +124,7 @@ function setCandidates(cands: Candidate[], highlighted: number, markText: string
   }
   else {
     hoverables.classList.remove('fcitx-horizontal-scroll')
-    if (scrollState === SCROLL_READY) {
-      requestAnimationFrame(() => {
-        // Set max-block-size as the actual value to enable expand animation.
-        hoverables.style.maxBlockSize = `${hoverables.getBoundingClientRect().height}px`
-      })
-    }
-    else {
+    if (scrollState !== SCROLL_READY) {
       // Cleanup all leftovers.
       hoverables.style.maxBlockSize = ''
     }

--- a/page/scroll.ts
+++ b/page/scroll.ts
@@ -282,6 +282,8 @@ hoverables.addEventListener('scroll', () => {
 const resizeObserver = new ResizeObserver((entries) => {
   if (scrollState === SCROLL_READY) {
     collapseHeight = entries[0].contentRect.height
+    // Set max-block-size as the actual value to enable expand animation.
+    hoverables.style.maxBlockSize = `${collapseHeight}px`
   }
   resizeForAnimation()
 })


### PR DESCRIPTION
When fcitx5 is debug build and typing fast, render has a lag and may cause `getBoundingClientRect` returning 0 height even in a requested animation frame.
Don't go back to a hacky way so no need to comment this in code.