### PR TITLE
vertical-rl: fix 🙅‍♂️ rotated on safari and split on chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@parcel/transformer-sass": "^2.14.4",
     "@playwright/test": "^1.52.0",
     "@types/node": "^22.15.3",
+    "emoji-regex": "^10.4.0",
     "eslint": "^9.25.1",
     "eslint-plugin-format": "^1.0.1",
     "parcel": "^2.14.4",

--- a/page/constant.ts
+++ b/page/constant.ts
@@ -2,6 +2,11 @@
 export const HORIZONTAL = 0
 export const VERTICAL = 1
 
+// WRITING_MODE
+export const HORIZONTAL_TB = 0
+export const VERTICAL_RL = 1
+export const VERTICAL_LR = 2
+
 // SCROLL_STATE
 export const SCROLL_NONE = 0
 export const SCROLL_READY = 1

--- a/page/global.d.ts
+++ b/page/global.d.ts
@@ -1,4 +1,4 @@
-import type { COLLAPSE, COMMIT, DOWN, END, HOME, HORIZONTAL, LEFT, PAGE_DOWN, PAGE_UP, RIGHT, SCROLL_NONE, SCROLL_READY, SCROLLING, UP, VERTICAL } from './constant'
+import type { COLLAPSE, COMMIT, DOWN, END, HOME, HORIZONTAL, HORIZONTAL_TB, LEFT, PAGE_DOWN, PAGE_UP, RIGHT, SCROLL_NONE, SCROLL_READY, SCROLLING, UP, VERTICAL, VERTICAL_LR, VERTICAL_RL } from './constant'
 
 declare global {
   type CONFIG_BOOL = 'False' | 'True'
@@ -94,6 +94,7 @@ declare global {
   }
 
   type LAYOUT = typeof HORIZONTAL | typeof VERTICAL
+  type WRITING_MODE = typeof HORIZONTAL_TB | typeof VERTICAL_RL | typeof VERTICAL_LR
 
   type SCROLL_STATE = typeof SCROLL_NONE | typeof SCROLL_READY | typeof SCROLLING
   type SCROLL_SELECT = 1 | 2 | 3 | 4 | 5 | 6
@@ -128,7 +129,7 @@ declare global {
     setTheme: (theme: 0 | 1 | 2) => void
     setAccentColor: (color: number | null | string) => void
     setStyle: (style: string) => void
-    setWritingMode: (mode: 0 | 1 | 2) => void
+    setWritingMode: (mode: WRITING_MODE) => void
     copyHTML: () => void
     scrollKeyAction: (action: SCROLL_KEY_ACTION) => void
     answerActions: (actions: CandidateAction[]) => void

--- a/tests/customize/test-typography.spec.ts
+++ b/tests/customize/test-typography.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test'
+import { VERTICAL, VERTICAL_RL } from '../../page/constant'
+import { candidate, init, setCandidates, setLayout, setWritingMode } from '../util'
+
+test('Emoji in vertical-rl', async ({ page }) => {
+  await init(page)
+  await setLayout(page, VERTICAL)
+  await setWritingMode(page, VERTICAL_RL)
+
+  await setCandidates(page, [
+    { text: '🙅‍♂️', label: '', comment: '', actions: [] }, // Single emoji to be upright.
+    { text: '字A🙅‍♂️', label: '', comment: '', actions: [] }, // Not able to make only emoji upright yet.
+    { text: '字A', label: '', comment: '', actions: [] }, // Control group.
+  ], 0)
+  await expect(candidate(page, 0).locator('.fcitx-text')).toHaveCSS('writing-mode', 'horizontal-tb')
+  await expect(candidate(page, 1).locator('.fcitx-text')).toHaveCSS('writing-mode', 'vertical-rl')
+  await expect(candidate(page, 2).locator('.fcitx-text')).toHaveCSS('writing-mode', 'vertical-rl')
+})

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -57,6 +57,11 @@ export function setLayout(page: Page, layout: LAYOUT) {
     window.fcitx.setLayout(layout), { layout })
 }
 
+export function setWritingMode(page: Page, mode: WRITING_MODE) {
+  return page.evaluate(({ mode }) =>
+    window.fcitx.setWritingMode(mode), { mode })
+}
+
 const defaultStyle: STYLE_JSON = {
   Advanced: {
     UserCss: '',


### PR DESCRIPTION
<img width="248" src="https://github.com/user-attachments/assets/ddfa0c70-0a4d-434c-a586-2b6e83c60aa9" />
<img width="267" src="https://github.com/user-attachments/assets/c19e4de9-9870-4be8-8755-e2c48f9dcec1" />
