### PR TITLE
feat: support dynamic candidate count in horizontal window and macOS style scroll navigation

### DIFF
--- a/include/webview_candidate_window.hpp
+++ b/include/webview_candidate_window.hpp
@@ -121,7 +121,7 @@ class WebviewCandidateWindow {
                             formatted auxDown);
     void set_candidates(std::vector<Candidate> candidates, int highlighted,
                         scroll_state_t scroll_state, bool scroll_start,
-                        bool scroll_end);
+                        bool scroll_end, bool dynamic = false);
     void set_layout(layout_t layout) { layout_ = layout; }
     void set_writing_mode(writing_mode_t mode) { writing_mode_ = mode; }
 
@@ -186,6 +186,7 @@ class WebviewCandidateWindow {
     scroll_state_t scroll_state_;
     bool scroll_start_;
     bool scroll_end_;
+    bool dynamic_ = false;
     mutable uint32_t epoch = 0; // A timestamp for async results from
                                 // webview
 

--- a/page/common.scss
+++ b/page/common.scss
@@ -374,7 +374,7 @@ $color-transition: var(--color-transition, background-color 500ms ease, color 50
       border-end-end-radius: calc($candidate-height / 2 + $border-width);
     }
 
-    .fcitx-panel:has(.fcitx-horizontal-scroll) {
+    .fcitx-panel:has(.fcitx-horizontal-scroll), .fcitx-panel:has(.fcitx-horizontal-dynamic) {
       /* Apply to panel to restrict both candidates and preedit width. */
       inline-size: calc($cell-width * var(--max-column, 6) + var(--scrollbar-redundancy-width, 2px) + var(--scrollbar-width, 8px) /* 2px redundance + 8px scrollbar making default 400px */);
     }

--- a/page/customize.ts
+++ b/page/customize.ts
@@ -1,5 +1,5 @@
 import { fixGhostStripe } from './ghost-stripe'
-import { setCaretText, setHighlightMarkText } from './panel'
+import { refreshDynamicCandidateLayout, setCaretText, setDynamicCandidateCount, setHighlightMarkText } from './panel'
 import { setAnimation, setScrollParams } from './scroll'
 import { theme } from './selector'
 import {
@@ -205,8 +205,10 @@ export function setStyle(style: string) {
   theme.style.setProperty('--max-row', j.ScrollMode.MaxRowCount)
   theme.style.setProperty('--max-column', j.ScrollMode.MaxColumnCount)
   setScrollParams(maxRow, maxColumn, cellWidth, candidateHeight)
+  setDynamicCandidateCount(j.ScrollMode.DynamicCandidateCount === 'True')
   theme.style.setProperty('--scrollbar-redundancy-width', j.ScrollMode.ShowScrollBar === 'False' ? '0px' : '2px')
   theme.style.setProperty('--scrollbar-width', j.ScrollMode.ShowScrollBar === 'False' ? '0px' : '8px')
+  refreshDynamicCandidateLayout()
   const animation = j.ScrollMode.Animation === 'True'
   theme.style.setProperty('--scroll-animation', animation ? '' : 'none')
   setAnimation(animation)

--- a/page/generic.scss
+++ b/page/generic.scss
@@ -200,6 +200,37 @@
       overflow-wrap: anywhere; /* Disallow long comment to introduce horizontal scrollbar. */
     }
   }
+
+  &.fcitx-horizontal-dynamic {
+    overflow: hidden;
+    overscroll-behavior: none;
+
+    .fcitx-candidate, .fcitx-divider, .fcitx-paging {
+      flex-shrink: 0;
+    }
+
+    .fcitx-candidate-inner {
+      flex: 1 1 0;
+      min-width: 0;
+      width: 100%;
+    }
+
+    .fcitx-comment {
+      overflow-wrap: anywhere;
+    }
+
+    .fcitx-dynamic-last {
+      flex-grow: 1;
+
+      .fcitx-divider-middle {
+        block-size: 0;
+      }
+
+      .fcitx-divider-side {
+        flex-grow: 1;
+      }
+    }
+  }
 }
 
 :is(.fcitx-vertical-rl, .fcitx-vertical-lr) .fcitx-paging svg {

--- a/page/global.d.ts
+++ b/page/global.d.ts
@@ -44,6 +44,7 @@ declare global {
       PagingButtonsStyle: PAGING_BUTTONS_STYLE
     }
     ScrollMode: {
+      DynamicCandidateCount: CONFIG_BOOL
       MaxRowCount: string
       MaxColumnCount: string
       ShowScrollBar: CONFIG_BOOL
@@ -143,7 +144,7 @@ declare global {
 
     // JavaScript APIs that webview_candidate_window.mm calls
     setHost: (system: string, version: number) => void
-    setCandidates: (cands: Candidate[], highlighted: number, pageable: boolean, hasPrev: boolean, hasNext: boolean, scrollState: SCROLL_STATE, scrollStart: boolean, scrollEnd: boolean) => void
+    setCandidates: (cands: Candidate[], highlighted: number, pageable: boolean, hasPrev: boolean, hasNext: boolean, scrollState: SCROLL_STATE, scrollStart: boolean, scrollEnd: boolean, dynamic?: boolean) => void
     setLayout: (layout: LAYOUT) => void
     updateInputPanel: (preCaret: [string, number][], hasCaret: boolean, postCaret: [string, number][], auxUp: [string, number][], auxDown: [string, number][]) => void
     hidePanel: () => void

--- a/page/panel.ts
+++ b/page/panel.ts
@@ -2,8 +2,8 @@ import emojiRegex from 'emoji-regex'
 import { SCROLL_NONE, SCROLL_READY, SCROLLING } from './constant'
 import { getLabelFormatter, setLastLabels } from './format-label'
 import { fixGhostStripe } from './ghost-stripe'
-import { fetchComplete, recalculateScroll, setScrollEnd, setScrollState } from './scroll'
-import { auxDown, auxUp, hoverables, preedit, theme } from './selector'
+import { fetchComplete, getCandidateAreaWidth, getDynamicCandidateCount, normalizeCandidateWidths, recalculateScroll, setDynamicCandidateCount as setDynamicCandidateCountState, setScrollEnd, setScrollState } from './scroll'
+import { auxDown, auxUp, hoverables, panel, preedit, theme } from './selector'
 import { div, getHoverBehavior, getPagingButtonsStyle, hideContextmenu, resetMouseMoveState, setActions } from './ux'
 
 const regex = emojiRegex()
@@ -37,6 +37,102 @@ export function setCaretText(text: string) {
   caretText = text
 }
 
+let currentScrollState: SCROLL_STATE = SCROLL_NONE
+let currentIsVertical = false
+let currentDynamic = false
+
+function resetDynamicCandidateLayout() {
+  const wasDynamic = hoverables.classList.contains('fcitx-horizontal-dynamic')
+  hoverables.classList.remove('fcitx-horizontal-dynamic')
+  if (!wasDynamic) {
+    return
+  }
+  hoverables.querySelectorAll('.fcitx-candidate, .fcitx-divider').forEach((element) => {
+    const candidate = element as HTMLElement
+    candidate.style.removeProperty('display')
+    candidate.style.removeProperty('width')
+    candidate.style.removeProperty('flex-grow')
+    element.classList.remove('fcitx-dynamic-last')
+  })
+}
+
+function recalculateDynamicCandidateLayout() {
+  if (currentIsVertical || currentScrollState === SCROLLING || !currentDynamic || !getDynamicCandidateCount()) {
+    resetDynamicCandidateLayout()
+    return
+  }
+
+  hoverables.classList.add('fcitx-horizontal-dynamic')
+  const candidates = Array.from(hoverables.querySelectorAll('.fcitx-candidate')) as HTMLElement[]
+  const paging = hoverables.querySelector('.fcitx-paging') as HTMLElement | null
+
+  for (const candidate of candidates) {
+    candidate.style.removeProperty('display')
+    candidate.style.removeProperty('width')
+    candidate.style.removeProperty('flex-grow')
+  }
+  for (const divider of hoverables.querySelectorAll('.fcitx-divider')) {
+    const element = divider as HTMLElement
+    element.style.removeProperty('display')
+    element.style.removeProperty('flex-grow')
+    element.classList.remove('fcitx-dynamic-last')
+  }
+
+  // Use the same cell rounding and row-break markers as scroll mode before
+  // hiding the candidates that are beyond the collapsed row.
+  normalizeCandidateWidths()
+
+  // Paging occupies the right edge of the collapsed row. Without paging, use
+  // the same candidate-area width as scroll mode.
+  const pagingDivider = paging?.previousElementSibling as HTMLElement | null
+  const hoverablesRect = hoverables.getBoundingClientRect()
+  const pagingWidth = paging?.getBoundingClientRect().width ?? 0
+  const pagingDividerWidth = pagingDivider?.getBoundingClientRect().width ?? 0
+  const limit = paging
+    ? Math.min(
+        paging.getBoundingClientRect().left,
+        hoverablesRect.right - pagingWidth - pagingDividerWidth,
+      )
+    : hoverablesRect.left + getCandidateAreaWidth()
+  let hide = false
+  let lastVisible = candidates.length - 1
+  for (let i = 0; i < candidates.length; ++i) {
+    const candidate = candidates[i]
+    // Keep the first candidate visible, matching scroll mode's handling of an
+    // item wider than the configured candidate area.
+    if (!hide && i > 0 && candidate.getBoundingClientRect().right > limit) {
+      hide = true
+      lastVisible = i - 1
+    }
+    if (hide) {
+      candidates[i].style.display = 'none'
+      const divider = candidate.nextElementSibling as HTMLElement | null
+      if (divider?.classList.contains('fcitx-divider') && !divider.classList.contains('fcitx-divider-paging')) {
+        divider.style.display = 'none'
+      }
+    }
+  }
+
+  // If the paging limit cuts through a scroll row, preserve the row-filling
+  // divider so the visible candidates keep the same alignment as scroll mode.
+  const lastVisibleDivider = candidates[lastVisible]?.nextElementSibling
+  if (lastVisibleDivider) {
+    lastVisibleDivider.classList.add('fcitx-dynamic-last')
+    lastVisibleDivider.removeAttribute('style')
+  }
+}
+
+export function setDynamicCandidateCount(enable: boolean) {
+  // Keep the setting in scroll.ts, which is also the source of the cell
+  // geometry used by the expanded view.
+  setDynamicCandidateCountState(enable)
+  recalculateDynamicCandidateLayout()
+}
+
+export function refreshDynamicCandidateLayout() {
+  recalculateDynamicCandidateLayout()
+}
+
 export function moveHighlight(from: Element | null, to: Element | null) {
   from?.classList.remove('fcitx-highlighted')
   to?.classList.add('fcitx-highlighted')
@@ -62,14 +158,20 @@ const caretRight = common.replace('{}', '0 0 192 512').replace('{}', 'M0 384.662
 const arrowBack = common.replace('{}', '0 0 24 24').replace('{}', 'M16.62 2.99a1.25 1.25 0 0 0-1.77 0L6.54 11.3a.996.996 0 0 0 0 1.41l8.31 8.31c.49.49 1.28.49 1.77 0s.49-1.28 0-1.77L9.38 12l7.25-7.25c.48-.48.48-1.28-.01-1.76z')
 const arrowForward = common.replace('{}', '0 0 24 24').replace('{}', 'M7.38 21.01c.49.49 1.28.49 1.77 0l8.31-8.31a.996.996 0 0 0 0-1.41L9.15 2.98c-.49-.49-1.28-.49-1.77 0s-.49 1.28 0 1.77L14.62 12l-7.25 7.25c-.48.48-.48 1.28.01 1.76z')
 
-export function setCandidates(cands: Candidate[], highlighted: number, pageable: boolean, hasPrev: boolean, hasNext: boolean, scrollState: SCROLL_STATE, scrollStart: boolean, scrollEnd: boolean) {
+export function setCandidates(cands: Candidate[], highlighted: number, pageable: boolean, hasPrev: boolean, hasNext: boolean, scrollState: SCROLL_STATE, scrollStart: boolean, scrollEnd: boolean, dynamic?: boolean) {
   if (cands.length) {
     // Auto layout requires display: not none so that getBoundingClientRect works.
     theme.classList.remove('fcitx-hidden')
   }
   const isVertical = hoverables.classList.contains('fcitx-vertical')
+  currentScrollState = scrollState
+  currentIsVertical = isVertical || !panel.classList.contains('fcitx-horizontal-tb')
+  // The native caller passes this per-update state explicitly. Keep omitted
+  // arguments compatible with the pre-dynamic WebView API.
+  currentDynamic = cands.length > 0 && dynamic === true && !currentIsVertical && scrollState !== SCROLLING
   resetMouseMoveState()
   hideContextmenu()
+  resetDynamicCandidateLayout()
   setScrollState(scrollState)
   // Clear existing candidates when scroll continues.
   if (scrollState !== SCROLLING || scrollStart) {
@@ -121,9 +223,9 @@ export function setCandidates(cands: Candidate[], highlighted: number, pageable:
       candidateInner.append(mark)
     }
 
-    if (cands[i].label || scrollState === SCROLLING) {
+    if (cands[i].label || scrollState === SCROLLING || currentDynamic) {
       const label = div('fcitx-label')
-      label.textContent = cands[i].label || label0
+      label.textContent = currentDynamic ? getLabelFormatter()((i + 1) % 10) : cands[i].label || label0
       candidateInner.append(label)
     }
 
@@ -200,6 +302,8 @@ export function setCandidates(cands: Candidate[], highlighted: number, pageable:
   else if (scrollState === SCROLLING) {
     recalculateScroll(scrollStart)
   }
+
+  recalculateDynamicCandidateLayout()
 
   for (const hoverable of hoverables.querySelectorAll('.fcitx-hoverable')) {
     hoverable.addEventListener('mousemove', () => {

--- a/page/panel.ts
+++ b/page/panel.ts
@@ -300,7 +300,7 @@ export function setCandidates(cands: Candidate[], highlighted: number, pageable:
     hoverables.appendChild(paging)
   }
   else if (scrollState === SCROLLING) {
-    recalculateScroll(scrollStart)
+    recalculateScroll(scrollStart, highlighted)
   }
 
   recalculateDynamicCandidateLayout()

--- a/page/scroll.ts
+++ b/page/scroll.ts
@@ -109,6 +109,9 @@ function distanceToTop(element: Element, basis: 'top' | 'bottom') {
 
 function scrollForHighlight() {
   const candidates = hoverables.querySelectorAll('.fcitx-candidate')
+  if (!candidates[highlighted]) {
+    return
+  }
 
   const bottomOffset = distanceToTop(candidates[highlighted], 'bottom') - hoverables.clientHeight
   // Highlighted candidate below bottom of panel
@@ -137,10 +140,12 @@ function renderHighlightAndLabels(newHighlighted: number, clearOld: boolean) {
     const skipped = itemCountInFirstNRows(highlightedRow)
     for (let i = skipped; i < skipped + rowItemCount[highlightedRow]; ++i) {
       const candidate = candidates[i]
-      candidate.classList.remove('fcitx-highlighted-row')
-      renderLabel(candidate, 0)
+      if (candidate) {
+        candidate.classList.remove('fcitx-highlighted-row')
+        renderLabel(candidate, 0)
+      }
     }
-    candidates[highlighted].classList.remove('fcitx-highlighted', 'fcitx-highlighted-original')
+    candidates[highlighted]?.classList.remove('fcitx-highlighted', 'fcitx-highlighted-original')
   }
 
   highlighted = newHighlighted
@@ -149,10 +154,12 @@ function renderHighlightAndLabels(newHighlighted: number, clearOld: boolean) {
   const skipped = itemCountInFirstNRows(highlightedRow)
   for (let i = skipped; i < skipped + rowItemCount[highlightedRow]; ++i) {
     const candidate = candidates[i]
-    candidate.classList.add('fcitx-highlighted-row')
-    renderLabel(candidate, (i - skipped + 1) % 10)
+    if (candidate) {
+      candidate.classList.add('fcitx-highlighted-row')
+      renderLabel(candidate, (i - skipped + 1) % 10)
+    }
   }
-  candidates[highlighted].classList.add('fcitx-highlighted', 'fcitx-highlighted-original')
+  candidates[highlighted]?.classList.add('fcitx-highlighted', 'fcitx-highlighted-original')
 }
 
 // Normalize candidate widths to the same cell grid used by scroll mode.
@@ -183,9 +190,15 @@ export function normalizeCandidateWidths() {
   return counts
 }
 
-export function recalculateScroll(scrollStart: boolean) {
+export function recalculateScroll(scrollStart: boolean, initialHighlighted?: number) {
   rowItemCount = normalizeCandidateWidths()
-  renderHighlightAndLabels(scrollStart ? 0 : highlighted, !scrollStart)
+  const targetHighlighted = scrollStart
+    ? (initialHighlighted !== undefined && initialHighlighted >= 0 ? initialHighlighted : 0)
+    : highlighted
+  renderHighlightAndLabels(targetHighlighted, !scrollStart)
+  if (scrollStart && targetHighlighted > 0) {
+    scrollForHighlight()
+  }
 }
 
 function getNeighborCandidate(index: number, direction: SCROLL_MOVE_HIGHLIGHT): number {

--- a/page/scroll.ts
+++ b/page/scroll.ts
@@ -13,6 +13,20 @@ let MAX_COLUMN = 6
 let UNIT_WIDTH = 65 // Math.floor((400 - 8)/MAX_COLUMN)
 let ROW_HEIGHT = 28
 
+let dynamicCandidateCount = false
+
+export function setDynamicCandidateCount(enable: boolean) {
+  dynamicCandidateCount = enable
+}
+
+export function getDynamicCandidateCount() {
+  return dynamicCandidateCount
+}
+
+export function getCandidateAreaWidth() {
+  return MAX_COLUMN * UNIT_WIDTH
+}
+
 export function setScrollParams(row: number, column: number, width: number, height: number) {
   MAX_ROW = row
   MAX_COLUMN = column
@@ -141,9 +155,12 @@ function renderHighlightAndLabels(newHighlighted: number, clearOld: boolean) {
   candidates[highlighted].classList.add('fcitx-highlighted', 'fcitx-highlighted-original')
 }
 
-export function recalculateScroll(scrollStart: boolean) {
+// Normalize candidate widths to the same cell grid used by scroll mode.
+// Keeping this shared with dynamic mode is important: the collapsed first row
+// must use exactly the same widths as the expanded first row.
+export function normalizeCandidateWidths() {
   const candidates = hoverables.querySelectorAll('.fcitx-candidate')
-  rowItemCount = []
+  const counts: number[] = []
   let itemCount = 0
   let unitCount = 0
   for (const candidate of candidates) {
@@ -156,13 +173,18 @@ export function recalculateScroll(scrollStart: boolean) {
       ++itemCount
     }
     else {
-      rowItemCount.push(itemCount)
+      counts.push(itemCount)
       candidate.previousElementSibling?.setAttribute('style', 'flex-grow: 1')
       itemCount = 1
       unitCount = nUnits
     }
   }
-  rowItemCount.push(itemCount)
+  counts.push(itemCount)
+  return counts
+}
+
+export function recalculateScroll(scrollStart: boolean) {
+  rowItemCount = normalizeCandidateWidths()
   renderHighlightAndLabels(scrollStart ? 0 : highlighted, !scrollStart)
 }
 
@@ -229,6 +251,14 @@ export function scrollKeyAction(action: SCROLL_KEY_ACTION) {
   hideContextmenu()
   if (action >= 0 && action <= 9) {
     const offset = (action + 9) % 10
+    if (hoverables.classList.contains('fcitx-horizontal-dynamic')) {
+      const candidates = Array.from(hoverables.querySelectorAll('.fcitx-candidate'))
+      const visibleCandidates = candidates.filter(candidate => getComputedStyle(candidate).display !== 'none')
+      if (offset >= visibleCandidates.length) {
+        return
+      }
+      return window.fcitx('select', candidates.indexOf(visibleCandidates[offset]))
+    }
     const highlightedRow = getHighlightedRow()
     const n = rowItemCount[highlightedRow]
     if (offset >= n) {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+packages: []
+
 allowBuilds:
   '@parcel/watcher': true
   '@swc/core': true

--- a/src/webview_candidate_window.cpp
+++ b/src/webview_candidate_window.cpp
@@ -127,13 +127,14 @@ void WebviewCandidateWindow::set_accent_color() const {
 void WebviewCandidateWindow::set_candidates(std::vector<Candidate> candidates,
                                             int highlighted,
                                             scroll_state_t scroll_state,
-                                            bool scroll_start,
-                                            bool scroll_end) {
+                                            bool scroll_start, bool scroll_end,
+                                            bool dynamic) {
     candidates_ = std::move(candidates);
     highlighted_ = highlighted;
     scroll_state_ = scroll_state;
     scroll_start_ = scroll_start;
     scroll_end_ = scroll_end;
+    dynamic_ = dynamic;
 }
 
 void WebviewCandidateWindow::scroll_key_action(
@@ -171,7 +172,7 @@ void WebviewCandidateWindow::show(double x, double y, double height) const {
     invoke_js("updateInputPanel", preeditPreCaret_, hasCaret_,
               preeditPostCaret_, auxUp_, auxDown_);
     invoke_js("setCandidates", candidates_, highlighted_, pageable_, has_prev_,
-              has_next_, scroll_state_, scroll_start_, scroll_end_);
+              has_next_, scroll_state_, scroll_start_, scroll_end_, dynamic_);
     invoke_js("resize", epoch, 0., 0., false);
 }
 

--- a/tests/customize/test-scroll.spec.ts
+++ b/tests/customize/test-scroll.spec.ts
@@ -153,8 +153,8 @@ test('Navigate down a row with DOWN and collapse on top row with UP', async ({ p
 
   // Pressing UP on top row triggers collapse
   await page.evaluate(() => window.fcitx.scrollKeyAction(10)) // UP = 10
-  // Wait for collapse timeout
-  await page.waitForTimeout(350)
-  const cppCalls = await getCppCalls(page)
-  expect(cppCalls.filter(call => JSON.stringify(call) === '{"scroll":[-1,0]}').length).toEqual(1)
+  await expect.poll(async () => {
+    const cppCalls = await getCppCalls(page)
+    return cppCalls.filter(call => JSON.stringify(call) === '{"scroll":[-1,0]}').length
+  }).toEqual(1)
 })

--- a/tests/customize/test-scroll.spec.ts
+++ b/tests/customize/test-scroll.spec.ts
@@ -121,3 +121,40 @@ test('Dynamic first row matches scroll candidate cells', async ({ page }) => {
   expect(dynamicInner.width).toBe(scrollInner.width)
   expect(dynamicInner.height).toBe(scrollInner.height)
 })
+
+test('Expand with initial highlight preserves selection', async ({ page }) => {
+  await init(page)
+  await setStyle(page, {
+    ScrollMode: { MaxColumnCount: '6' },
+  })
+  const texts = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10']
+  await scrollExpand(page, texts, 2)
+  await expect(candidate(page, 2)).toContainClass('fcitx-highlighted')
+  const cppCalls = await getCppCalls(page)
+  expect(cppCalls.filter(call => JSON.stringify(call) === '{"highlight":[2]}').length).toBeGreaterThanOrEqual(1)
+})
+
+test('Navigate down a row with DOWN and collapse on top row with UP', async ({ page }) => {
+  await init(page)
+  await setStyle(page, {
+    ScrollMode: { MaxColumnCount: '6' },
+  })
+  const texts = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']
+  await scrollExpand(page, texts, 1)
+  await expect(candidate(page, 1)).toContainClass('fcitx-highlighted')
+
+  // Move down to next row
+  await page.evaluate(() => window.fcitx.scrollKeyAction(11)) // DOWN = 11
+  await expect(candidate(page, 7)).toContainClass('fcitx-highlighted')
+
+  // Move back up to top row
+  await page.evaluate(() => window.fcitx.scrollKeyAction(10)) // UP = 10
+  await expect(candidate(page, 1)).toContainClass('fcitx-highlighted')
+
+  // Pressing UP on top row triggers collapse
+  await page.evaluate(() => window.fcitx.scrollKeyAction(10)) // UP = 10
+  // Wait for collapse timeout
+  await page.waitForTimeout(350)
+  const cppCalls = await getCppCalls(page)
+  expect(cppCalls.filter(call => JSON.stringify(call) === '{"scroll":[-1,0]}').length).toEqual(1)
+})

--- a/tests/customize/test-scroll.spec.ts
+++ b/tests/customize/test-scroll.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test'
-import { candidate, getCppCalls, init, panel, scrollExpand, setStyle } from '../util'
+import { candidate, getBox, getCppCalls, init, panel, scrollExpand, scrollReady, setStyle } from '../util'
 
 test('Row, column and cell width', async ({ page }) => {
   await init(page)
@@ -37,4 +37,87 @@ test('Hide scrollbar', async ({ page }) => {
   await scrollExpand(page, Array.from({ length: 42 }).map((_, i) => (i + 1).toString()))
   const pane = panel(page)
   await expect(pane).toHaveCSS('width', '390px')
+})
+
+test('Dynamic candidate count in collapsed horizontal mode', async ({ page }) => {
+  await init(page)
+  await setStyle(page, {
+    ScrollMode: { MaxColumnCount: '6' },
+  })
+  await scrollReady(page, Array.from({ length: 7 }).map(() => ({ text: '短' })), 0, true)
+
+  await expect(panel(page)).toHaveCSS('width', '400px')
+  await expect(page.locator('.fcitx-expand')).toBeVisible()
+  await expect(page.locator('.fcitx-candidate:visible')).toHaveCount(5)
+})
+
+test('Dynamic candidate count selects only visible candidates', async ({ page }) => {
+  await init(page)
+  await setStyle(page, {
+    ScrollMode: { MaxColumnCount: '6' },
+  })
+  await scrollReady(page, Array.from({ length: 7 }).map(() => ({ text: '短' })), 0, true)
+
+  await page.evaluate(() => window.fcitx.scrollKeyAction(6))
+  expect((await getCppCalls(page)).filter(call => 'select' in call)).toEqual([])
+
+  await page.evaluate(() => window.fcitx.scrollKeyAction(4))
+  expect((await getCppCalls(page)).filter(call => 'select' in call)).toEqual([{ select: [3] }])
+})
+
+test('Dynamic candidate count can be enabled without scroll state', async ({ page }) => {
+  await init(page)
+  await setStyle(page, {
+    ScrollMode: { MaxColumnCount: '6' },
+  })
+  const cands = Array.from({ length: 7 }).map(() => ({ text: '短', label: '', comment: '', actions: [], spaceBetweenComment: true }))
+  await page.evaluate(({ cands }) => window.fcitx.setCandidates(cands, 0, false, false, false, 0, false, false, true), { cands })
+  await expect(page.locator('.fcitx-candidate:visible')).toHaveCount(6)
+})
+
+test('Dynamic candidate count can be disabled', async ({ page }) => {
+  await init(page)
+  await setStyle(page, {
+    ScrollMode: { MaxColumnCount: '6' },
+  })
+  await scrollReady(page, Array.from({ length: 7 }).map(() => ({ text: '短' })), 0, true)
+  await expect(page.locator('.fcitx-candidate:visible')).toHaveCount(5)
+
+  await setStyle(page, {
+    ScrollMode: { DynamicCandidateCount: 'False' },
+  })
+  await expect(page.locator('.fcitx-expand')).toBeVisible()
+  await expect(page.locator('.fcitx-candidate:visible')).toHaveCount(7)
+
+  await setStyle(page, {
+    ScrollMode: { DynamicCandidateCount: 'True' },
+  })
+  await expect(page.locator('.fcitx-candidate:visible')).toHaveCount(5)
+})
+
+test('Dynamic first row matches scroll candidate cells', async ({ page }) => {
+  await init(page)
+  await setStyle(page, {
+    Font: { LabelFontSize: '24', TextFontSize: '40' },
+    ScrollMode: { MaxColumnCount: '6' },
+    Size: { OverrideDefault: 'True', ScrollCellWidth: '130' },
+  })
+  const cands = [
+    { label: '1', text: '动态码', comment: '', actions: [], spaceBetweenComment: true },
+    { label: '2', text: '动态漫', comment: '', actions: [], spaceBetweenComment: true },
+    { label: '3', text: '动态美', comment: '', actions: [], spaceBetweenComment: true },
+    { label: '4', text: '动态嗨', comment: '', actions: [], spaceBetweenComment: true },
+  ]
+  await page.evaluate(({ cands }) => window.fcitx.setCandidates(cands, 0, false, false, false, 1, false, false, true), { cands })
+  const dynamicCandidate = await getBox(candidate(page, 0))
+  const dynamicInner = await getBox(candidate(page, 0).locator('.fcitx-candidate-inner'))
+
+  await page.evaluate(({ cands }) => window.fcitx.setCandidates(cands, -1, false, false, false, 2, true, false), { cands })
+  const scrollCandidate = await getBox(candidate(page, 0))
+  const scrollInner = await getBox(candidate(page, 0).locator('.fcitx-candidate-inner'))
+
+  expect(dynamicCandidate.width).toBe(scrollCandidate.width)
+  expect(dynamicCandidate.height).toBe(scrollCandidate.height)
+  expect(dynamicInner.width).toBe(scrollInner.width)
+  expect(dynamicInner.height).toBe(scrollInner.height)
 })

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -43,6 +43,11 @@ export async function scrollExpand(page: Page, texts: string[]) {
     window.fcitx.setCandidates(cands, -1, false, false, false, 2, true, false), { cands })
 }
 
+export function scrollReady(page: Page, cands: Partial<Candidate>[], highlighted = 0, dynamic = false) {
+  return page.evaluate(({ cands, highlighted, dynamic }) =>
+    window.fcitx.setCandidates(cands.map(cand => ({ text: 'text', label: '1', comment: '', actions: [], spaceBetweenComment: true, ...cand })), highlighted, false, false, false, 1, false, false, dynamic), { cands, highlighted, dynamic })
+}
+
 export function scroll(page: Page, texts: string[], scrollEnd: boolean) {
   const cands = texts.map(text => ({ text, label: '', comment: '', actions: [], spaceBetweenComment: true }))
   return page.evaluate(({ cands, scrollEnd }) =>
@@ -150,6 +155,7 @@ const defaultStyle: STYLE_JSON = {
   },
   ScrollMode: {
     Animation: 'True',
+    DynamicCandidateCount: 'True',
     MaxRowCount: '6',
     MaxColumnCount: '6',
     ShowScrollBar: 'True',

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -35,12 +35,12 @@ export function setCandidates(page: Page, cands: Partial<Candidate>[], highlight
     window.fcitx.setCandidates(cands.map(cand => ({ text: 'text', label: '1', comment: 'comment', actions: [], spaceBetweenComment: true, ...cand })), highlighted, pageable, hasPrev, false, 0, false, false), { cands, highlighted, pageable, hasPrev })
 }
 
-export async function scrollExpand(page: Page, texts: string[]) {
+export async function scrollExpand(page: Page, texts: string[], highlighted = 0) {
   const cands = texts.map(text => ({ text, label: '', comment: '', actions: [], spaceBetweenComment: true }))
-  await page.evaluate(({ cands }) =>
-    window.fcitx.setCandidates(cands, 0, false, false, false, 1, false, false), { cands })
-  return page.evaluate(({ cands }) =>
-    window.fcitx.setCandidates(cands, -1, false, false, false, 2, true, false), { cands })
+  await page.evaluate(({ cands, highlighted }) =>
+    window.fcitx.setCandidates(cands, highlighted, false, false, false, 1, false, false), { cands, highlighted })
+  return page.evaluate(({ cands, highlighted }) =>
+    window.fcitx.setCandidates(cands, highlighted, false, false, false, 2, true, false), { cands, highlighted })
 }
 
 export function scrollReady(page: Page, cands: Partial<Candidate>[], highlighted = 0, dynamic = false) {


### PR DESCRIPTION
## 概述

本 PR 为 Webview 候选词窗口实现了**水平单行动态候选词数量**展示，并增加了 **macOS 原生风格的多行展开/折叠与行间键盘导航**支持。

## 核心改动

### 1. 水平单行动态候选词数量 (`dynamic`)
- **自适应宽度排版**：当启用 `dynamic` 时，容器添加 `fcitx-horizontal-dynamic` 类。根据面板设定宽度自适应计算并展示能容纳的候选词，末尾超出宽度的候选词自动隐藏。
- **单元格尺寸对齐**：对齐单行动态模式与多行滚动模式下候选词项的内边距、行高与字体基线，确保展开过渡视觉一致。
- **按键选择与交互对齐**：数字选词键（`1`–`9`, `0`）与点击事件在动态模式下严格映射到当前实际可见的候选词索引。

### 2. 滚动展开态多行导航与折叠
- **展开时保持高亮**：单行状态下选中的候选词在展开进入多行滚动视图时无缝保持高亮，不重置选择。
- **多行上下行导航 (`Up` / `Down`)**：
  - `Down`：将高亮切换至下一行的对应列位置。
  - `Up`：将高亮切换至上一行的对应列位置。
  - **首行折叠触发**：当高亮位于第一行再次按 `Up` 时，触发收起动画并调用 `scroll(-1, 0)` 折叠回单行候选框（与原生 macOS 拼音行为一致）。

### 3. C++ 接口与 JS Bridge 更新
- `WebviewCandidateWindow::set_candidates` 与前端 `window.fcitx.setCandidates` 新增 `dynamic` 参数。

### 4. 自动化测试 (`tests/customize/test-scroll.spec.ts`)
- 新增 Playwright 测试用例：
  - 水平动态模式下根据面板宽度自适应截断不可见词；
  - 动态模式下仅允许选择可见候选词；
  - 动态模式开关切换生效；
  - 动态单行与滚动多行单元格尺寸严格一致；
  - 展开时候选词高亮位置正确保持；
  - 多行 `Down` / `Up` 导航以及首行按 `Up` 触发折叠。

## 验证

- [x] `pnpm test` 全部测试通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic candidate sizing for horizontal layouts, allowing the candidate panel to use available space more effectively.
  * Added a configuration option to enable or disable dynamic candidate counts.
  * Improved candidate selection, highlighting, scrolling, and navigation when dynamic sizing is enabled.

* **Bug Fixes**
  * Improved panel sizing, overflow handling, divider alignment, and layout refresh behavior across candidate display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->