### PR TITLE
hide contextmenu when clicking outside

### DIFF
--- a/page/ux.ts
+++ b/page/ux.ts
@@ -229,6 +229,17 @@ let receiver: HTMLElement
 export function initUx() {
   receiver = (window.fcitx.distribution === 'fcitx5-js' ? decoration : document) as HTMLElement
 
+  // Hide contextmenu when clicking outside.
+  receiver.addEventListener('mouseup', (e) => {
+    if (e.button !== 0 || contextmenu.style.display !== 'block' || contextmenu.contains(e.target as Node)) {
+      return
+    }
+    hideContextmenu()
+    pressed = false
+    dragging = false
+    e.stopImmediatePropagation()
+  }, true)
+
   hoverables.addEventListener('mouseleave', () => {
     const hoverBehavior = getHoverBehavior()
     if (hoverBehavior === 'Move') {

--- a/tests/test-generic.spec.ts
+++ b/tests/test-generic.spec.ts
@@ -114,6 +114,23 @@ test('Candidate action', async ({ page }) => {
   expect(cppCalls.at(-1)).toEqual({ action: [0, 1] })
 })
 
+test('Clicking outside candidate action closes it without selecting', async ({ page }) => {
+  await init(page)
+  await setCandidates(page, [
+    { text: '不要选择', label: '1', comment: '', actions: [] },
+    { text: '可遗忘', label: '2', comment: '', actions: [{ id: 1, text: '忘记' }] },
+  ], 0)
+
+  await candidate(page, 1).click({ button: 'right' })
+  const contextmenu = page.locator('.fcitx-contextmenu')
+  await expect(contextmenu).toBeVisible()
+
+  await candidate(page, 0).click()
+  await expect(contextmenu).toBeHidden()
+  const cppCalls = await getCppCalls(page)
+  expect(cppCalls.some(call => 'select' in call || 'action' in call)).toBe(false)
+})
+
 test('Drag should not select candidate', async ({ page }) => {
   await init(page)
   await setCandidates(page, [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Context menus now close when clicking outside the menu, including when selecting another candidate.
  * Prevented unintended selection or actions when dismissing an open context menu.

* **Tests**
  * Added coverage verifying that context menus close correctly without triggering candidate actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->